### PR TITLE
Add Node.js promotion engine with React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# codex-promotion-engine
+# Promotion Engine
+
+This project provides a Node.js backend with an in-memory SQLite database and a React frontend.
+
+## Setup
+
+```bash
+npm install
+npm --prefix client install
+```
+
+## Development
+
+Run the server:
+
+```bash
+npm start
+```
+
+Run tests and linters:
+
+```bash
+npm test
+npm run lint
+npm run client:test
+npm run client:lint
+```

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "promotion-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.0.0",
+    "eslint": "^8.56.0",
+    "jest": "^29.6.0"
+  },
+  "scripts": {
+    "test": "jest",
+    "lint": "eslint src"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Promotion Engine</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,0 +1,9 @@
+.app {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  padding: 2rem;
+}
+.result {
+  margin-top: 1rem;
+  font-weight: bold;
+}

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import './App.css';
+
+function App() {
+  const [promos, setPromos] = useState([]);
+  const [code, setCode] = useState('');
+  const [amount, setAmount] = useState(100);
+  const [result, setResult] = useState(null);
+
+  useEffect(() => {
+    fetch('/promotions')
+      .then(res => res.json())
+      .then(setPromos);
+  }, []);
+
+  const apply = () => {
+    fetch('/promotions/apply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code, amount: parseInt(amount, 10) })
+    })
+      .then(res => res.json())
+      .then(setResult);
+  };
+
+  return (
+    <div className="app">
+      <h1>Promotion Engine</h1>
+      <div>
+        <input value={code} onChange={e => setCode(e.target.value)} placeholder="Code" />
+        <input type="number" value={amount} onChange={e => setAmount(e.target.value)} />
+        <button onClick={apply}>Apply</button>
+      </div>
+      {result && (
+        <div className="result">New amount: {result.amount}</div>
+      )}
+      <ul>
+        {promos.map(p => (
+          <li key={p.id}>{p.name} - {p.code}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default App;

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+test('renders title', () => {
+  render(<App />);
+  const linkElement = screen.getByText(/Promotion Engine/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,12 @@
+import js from '@eslint/js';
+import react from 'eslint-plugin-react';
+
+export default [
+  js.configs.recommended,
+  {
+    plugins: { react },
+    rules: {
+      'react/react-in-jsx-scope': 'off'
+    }
+  }
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "promotion-engine",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": ["client"],
+  "scripts": {
+    "start": "node server/index.js",
+    "test": "jest",
+    "lint": "eslint server",
+    "client:test": "npm --prefix client test",
+    "client:lint": "npm --prefix client run lint"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "body-parser": "^1.20.2",
+    "sqlite3": "^5.1.6"
+  },
+  "devDependencies": {
+    "jest": "^29.6.0",
+    "supertest": "^6.3.3",
+    "eslint": "^8.56.0"
+  },
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/server/__tests__/apply.test.js
+++ b/server/__tests__/apply.test.js
@@ -1,0 +1,24 @@
+const request = require('supertest');
+const express = require('express');
+const bodyParser = require('body-parser');
+const promotionsRouter = require('../routes/promotions');
+const db = require('../db');
+
+const app = express();
+app.use(bodyParser.json());
+app.use('/promotions', promotionsRouter);
+
+describe('promotion apply', () => {
+  beforeAll(done => {
+    const stmt = db.prepare('INSERT INTO promotions (name, code, discount, budget, capping) VALUES (?, ?, ?, ?, ?)');
+    stmt.run('Test', 'TEST', 10, 100, 5, done);
+  });
+
+  it('applies a promo code', async () => {
+    const res = await request(app)
+      .post('/promotions/apply')
+      .send({ code: 'TEST', amount: 50 });
+    expect(res.status).toBe(200);
+    expect(res.body.amount).toBe(40);
+  });
+});

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,17 @@
+const sqlite3 = require('sqlite3').verbose();
+
+const db = new sqlite3.Database(':memory:');
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS promotions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    code TEXT UNIQUE NOT NULL,
+    discount INTEGER NOT NULL,
+    budget INTEGER NOT NULL,
+    capping INTEGER NOT NULL,
+    uses INTEGER DEFAULT 0
+  )`);
+});
+
+module.exports = db;

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const promotionsRouter = require('./routes/promotions');
+
+const app = express();
+app.use(bodyParser.json());
+
+app.use('/promotions', promotionsRouter);
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server/routes/promotions.js
+++ b/server/routes/promotions.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const db = require('../db');
+
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  db.all('SELECT * FROM promotions', (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+router.post('/', (req, res) => {
+  const { name, code, discount, budget, capping } = req.body;
+  const stmt = db.prepare(`INSERT INTO promotions (name, code, discount, budget, capping) VALUES (?, ?, ?, ?, ?)`);
+  stmt.run(name, code, discount, budget, capping, function(err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ id: this.lastID });
+  });
+});
+
+router.post('/apply', (req, res) => {
+  const { code, amount } = req.body;
+  db.get('SELECT * FROM promotions WHERE code = ?', [code], (err, promo) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!promo) return res.status(404).json({ error: 'Promo not found' });
+    if (promo.uses >= promo.capping) return res.status(400).json({ error: 'Promo capping reached' });
+    if (promo.budget < promo.discount) return res.status(400).json({ error: 'Promo budget exceeded' });
+
+    const newAmount = amount - promo.discount;
+    db.run('UPDATE promotions SET uses = uses + 1, budget = budget - ? WHERE id = ?', [promo.discount, promo.id], err2 => {
+      if (err2) return res.status(500).json({ error: err2.message });
+      res.json({ amount: newAmount });
+    });
+  });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- implement Express server with in-memory SQLite
- add endpoints to create and apply promotions
- implement minimal React client
- add Jest tests and eslint config
- update README with setup instructions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find eslint package)*
- `npm run client:test` *(fails: jest not found)*
- `npm run client:lint` *(fails: cannot find eslint package)*

------
https://chatgpt.com/codex/tasks/task_b_6846dad38cc88330a860391f205b497b